### PR TITLE
Add Dockerfile for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:jessie
+MAINTAINER Surligas Manolis <surligas@csd.uoc.gr>
+MAINTAINER Antonios Chariton <daknob@daknob.net>
+
+# Update Image
+RUN apt-get update
+RUN apt-get -y -q upgrade
+
+# Install Developer Tools
+RUN apt-get -y -q install binutils g++
+
+# Install CMake
+RUN apt-get -y -q install cmake
+
+# Move source code
+RUN mkdir /software
+COPY CMakeLists.txt /software/CMakeLists.txt
+COPY cmake_uninstall.cmake.in /software/cmake_uninstall.cmake.in
+COPY lib /software/lib
+COPY test /software/test
+COPY utils /software/utils
+
+# Compile Program
+ENV CXX gcc
+RUN cd /software && mkdir build && cd build && cmake .. && make
+
+# Set which program to run
+ENV RUNBIN test_microtcp_client
+
+# Execute Program
+CMD ["sh", "-c", "/software/build/test/${RUNBIN}"]


### PR DESCRIPTION
This Pull Request adds a `Dockerfile` to the main directory of the project.

Assuming a computer with `docker.io` installed (or Boot2Docker), the user can invoke:

``` bash
docker build .
docker run $ContainerHash
```

to automatically build and run the script inside a Docker Container. 

The benefits of this is that due to the Docker design, all builds of this script will be reproducible and there is a guarantee that it will react the same under all operating systems (Mac OS X, Linux, Windows). Moreover, the computers this Project will be examined on run the same Debian Jessie version with the same software versions. This increases the probability of working without discrepancies even when developing in a completely different OS. 
