### PR TITLE
Automate Docker Runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ cd build
 cmake ..
 
 make
+
+## Run Directly in Docker
+
+```bash
+./rund $TestToRun
+```
+
+Example:
+
+```bash
+./rund test_microtcp_server
+```

--- a/rund
+++ b/rund
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -e "RUNBIN=$1" --net="bridge" $(docker build . | grep Successfully | cut -d" " -f3)


### PR DESCRIPTION
This Pull Request introduces a script to quickly run the tests inside a Docker Container by using the `Dockerfile` of Pull #1 .

Its usage is documented in the `README.md` file for ease of use but is also included here:

``` bash
./rund $BinaryToRun
```

For example, you could invoke:

``` bash
./rund test_microtcp_server
```
